### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) for transparency. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains.
 
-The PSL project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL.
+The PSL-Infrastructure project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL.
 
 PSL infrastructure projects under development include:
 
 - A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool.
 - The [pslmodels.org](https://www.pslmodels.org) website to host general Library information and the PSL-Catalog.
-- Broadcast-Recipes for disseminating updates about the projects to users.
-- A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."
+- Recipes for sharing projects with users.
 
 The PSL's online home for users is [https://www.pslmodels.org](https://www.pslmodels.org).
 


### PR DESCRIPTION
In the README:

- Refers to self as Infrastructure.
- Drops discussion of a privacy-granting service, as I no longer think it is a good fit for a project like PSL-Infrastructure.
- Drops mention of Broadcast-Recipes as a thing w/ a Name, as we have not consolidated any outreach activities into such a project at this time. 