### PR TITLE
Remove 2-4 interoperability criteria

### DIFF
--- a/Criteria/library_criteria.md
+++ b/Criteria/library_criteria.md
@@ -62,9 +62,6 @@ Interoperability Criteria
 --------------------------
 
 1. The source code SHOULD be written in an open source language.
-1. All input and output variables SHOULD be documented like...
-1. All policy parameters and assumptions SHOULD be documented like...
-1. Meta information about your project SHOULD be documented like...
 1. A `PSL_catalog.json` configuration file to be used for cataloging these criteria MUST be included in the project's repository. Specific instructions for creating this file can be found in the [Catalog-Builder Documentation][2].
 
 


### PR DESCRIPTION
Interoperability criteria 2-4 were not defined and not being used by PSL-Infrastructure. This PR removes them. 

If PSL-Infrastructure provides technology in the future that would benefit from similar criteria, such as centralized project websites or documentation sites, then we can add the helpful criteria at that point. 

Given that the criteria were not defined, I am not going to set up a formal meeting of the PSL leadership council to approve these changes, but I will leave the PR open for at least 24 hours for comments. 

Also, resolves #14. 