### PR TITLE
Add Tax-Cruncher to the PSL Catalog

### DIFF
--- a/Catalog/catalog.json
+++ b/Catalog/catalog.json
@@ -502,5 +502,39 @@
             "source": null,
             "value": null
         }
+    },
+    "Tax-Cruncher": {
+        "name": {
+            "value": "Tax-Cruncher",
+            "source": ""
+        },
+        "project_one_line": {
+            "source": "https://github.com/PSLmodels/Tax-Cruncher",
+            "value": "<p>Calculates federal tax liabilities from individual data under different policy proposals</p>"
+        },
+        "project_overview": {
+            "source": "https://github.com/PSLmodels/Tax-Cruncher/blob/master/README.md",
+            "value": "<p>Tax-Cruncher calculates federal tax liabilities from individual data under different policy proposals. </p> <p>Tax-Cruncher accepts inputs similar to NBER's <a href=\"https://users.nber.org/~taxsim/taxsim27/\">TAXSIM Version 27</a>, converts those inputs to a format usable by <a href=\"https://github.com/PSLmodels/Tax-Calculator\">Tax-Calculator</a>, an open-source microsimulation model of federal individual income and payroll tax law, and uses Tax-Calculator capabilities to analyze the user-specified inputs under various tax policy proposals.</p> <p>Tax-Cruncher's web application is hosted on <a href=\"https://www.compmodels.org/PSLmodels/Tax-Cruncher/\">COMP</a>. The code that powers the web application can be found in this repository in the <a href=\"https://github.com/PSLmodels/Tax-Cruncher/tree/master/compconfig\">compconfig</a> directory.</p>"
+        },
+        "user_documentation": {
+            "source": "https://github.com/PSLmodels/Tax-Cruncher#how-to-use-tax-cruncher",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Cruncher#how-to-use-tax-cruncher\">https://github.com/PSLmodels/Tax-Cruncher#how-to-use-tax-cruncher</a>"
+        },
+        "user_changelog_recent": {
+            "source": "https://github.com/PSLmodels/Tax-Cruncher/releases",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Cruncher/releases\">https://github.com/PSLmodels/Tax-Cruncher/releases</a>"
+        },
+        "contributor_overview": {
+            "source": null,
+            "value": null
+        },
+        "link_to_webapp": {
+            "source": null,
+            "value": "<a href=\"https://www.compmodels.org/PSLmodels/Tax-Cruncher/\">Tax-Cruncher</a>"
+        },
+        "core_maintainers": {
+            "source": null,
+            "value": "<ul><li>Peter Metz</li></ul>"
+        }
     }
 }

--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -284,6 +284,46 @@
                         </div>
                     </div>
                 
+                    <div class="card">
+                        <div class="card-header" id="Tax-Cruncher" style="background-color:#e4e9ec">
+                                <h2>
+                                    <a href="" style="color:inherit;" data-toggle="collapse" data-target="#Tax-Cruncher-collapse">Tax-Cruncher</a>
+                                    <div class="float-right">
+                                        <button
+                                            class="btn collapse-button"
+                                            type="button"
+                                            data-toggle="collapse"
+                                            data-target="#Tax-Cruncher-collapse"
+                                            aria-expanded="false"
+                                            aria-controls="Tax-Cruncher-collapse"
+                                            style="margin-left:20px;">
+                                            <i class="far fa-plus-square" style="size:.5x;"></i>
+                                        </button>
+                                    </div>
+                                </h2>
+                                <p>Calculates federal tax liabilities from individual data under different policy proposals</p>
+                        </div>
+                        <div class="collapse" id="Tax-Cruncher-collapse" aria-labelledby="" data-parent="#accordionParent">
+                            <div class="container">
+                                <p><p>Tax-Cruncher calculates federal tax liabilities from individual data under different policy proposals. </p> <p>Tax-Cruncher accepts inputs similar to NBER's <a href="https://users.nber.org/~taxsim/taxsim27/">TAXSIM Version 27</a>, converts those inputs to a format usable by <a href="https://github.com/PSLmodels/Tax-Calculator">Tax-Calculator</a>, an open-source microsimulation model of federal individual income and payroll tax law, and uses Tax-Calculator capabilities to analyze the user-specified inputs under various tax policy proposals.</p> <p>Tax-Cruncher's web application is hosted on <a href="https://www.compmodels.org/PSLmodels/Tax-Cruncher/">COMP</a>. The code that powers the web application can be found in this repository in the <a href="https://github.com/PSLmodels/Tax-Cruncher/tree/master/compconfig">compconfig</a> directory.</p></p>
+                                <h6>Maintainers</h6>
+                                <ul><li>Peter Metz</li></ul>
+                                <p><a href="https://github.com/PSLmodels/Tax-Cruncher#readme">Code repository</a></p>
+                                <p><a href="https://github.com/PSLmodels/Tax-Cruncher#how-to-use-tax-cruncher">User documentation</a>
+</p><p><a href="https://github.com/PSLmodels/Tax-Cruncher/releases">Recent changes</a>
+</p><p><a href="https://www.compmodels.org/PSLmodels/Tax-Cruncher/">Link to webapp</a>
+</p>
+                            </div>
+                            <script type="text/javascript">
+                                var url = document.location.toString();
+                                if ( url.match('#') ) {
+                                    var section = $('#'+url.split('#')[1]+'-collapse');
+                                    section.collapse('show');
+                                }
+                            </script>
+                        </div>
+                    </div>
+                
             </div>
         </div>
     </body>

--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -28,5 +28,10 @@
         "org": "PSLmodels",
         "repo": "Tax-Brain",
         "branch": "master"
+    },
+    {
+        "org": "PSLmodels",
+        "repo": "Tax-Cruncher",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
This PR adds [Tax-Cruncher](https://github.com/PSLmodels/Tax-Cruncher) to the catalog builder's `register.json`, thereby adding it to the PSL Catalog.