### PR TITLE
WZ PSL-lc project -> PCI-China

### DIFF
--- a/Community/council.md
+++ b/Community/council.md
@@ -11,7 +11,7 @@
 | Martin Holmer   | Tax-Calculator             | martin.holmer@gmail.com  |
 | Matt Jensen     | PSL-Infrastructure         | matt.h.jensen@gmail.com  |
 | Peter Metz      | Tax-Cruncher               | pmetzdc@gmail.com        |
-| Weifeng Zhong   | Policy-Change-Index        | weifeng@weifengzhong.com |
+| Weifeng Zhong   | PCI-China                  | weifeng@weifengzhong.com |
 
 
 ## Bylaws 


### PR DESCRIPTION
This specifies that @towashington's role on the council is to represent the PCI-China project rather than the PCI umbrella brand. 