### PR TITLE
Add donate link to top of pages

### DIFF
--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -33,6 +33,7 @@
                     <li class="nav-item active"><a class="nav-link" href="../events.html">Events</a></li>
                     <li class="nav-item active"><a class="nav-link" href="../Newsletter/archive.html">Newsletter</a></li>
                     <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
                 </ul>
             </div>
             <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">
@@ -45,7 +46,7 @@
             <br>
             <div class="accordion" id="accordionParent">
                 <!-- Create a collapsible card for each model in PSL -->
-                
+
                     <div class="card">
                         <div class="card-header" id="Behavioral-Responses" style="background-color:#e4e9ec">
                                 <h2>
@@ -85,7 +86,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Cost-of-Capital-Calculator" style="background-color:#e4e9ec">
                                 <h2>
@@ -124,7 +125,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="OG-USA" style="background-color:#e4e9ec">
                                 <h2>
@@ -163,7 +164,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="PCI-China" style="background-color:#e4e9ec">
                                 <h2>
@@ -202,7 +203,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="ParamTools" style="background-color:#e4e9ec">
                                 <h2>
@@ -242,7 +243,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Brain" style="background-color:#e4e9ec">
                                 <h2>
@@ -283,7 +284,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Calculator" style="background-color:#e4e9ec">
                                 <h2>
@@ -323,7 +324,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Cruncher" style="background-color:#e4e9ec">
                                 <h2>
@@ -363,7 +364,7 @@
                             </script>
                         </div>
                     </div>
-                
+
             </div>
         </div>
     </body>

--- a/Newsletter/archive.html
+++ b/Newsletter/archive.html
@@ -7,7 +7,7 @@
          window.dataLayer = window.dataLayer || [];
          function gtag(){dataLayer.push(arguments);}
          gtag('js', new Date());
-         
+
          gtag('config', 'UA-128365658-1');
       </script>
       <meta charset="utf-8">
@@ -33,6 +33,7 @@
                <li class="nav-item active"><a class="nav-link" href="../events.html">Events</a></li>
                <li class="nav-item active"><a class="nav-link" href="archive.html">Newsletter</a></li>
                <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+               <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
             </ul>
          </div>
          <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">
@@ -59,7 +60,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>*|MC:SUBJECT|*</title>
-        
+
     <style type="text/css">
             p{
                   margin:10px 0;
@@ -625,11 +626,11 @@
                     <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer" style="min-width:100%;">
                         <tbody><tr>
                             <td class="mcnImageContent" valign="top" style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
-                                
-                                    
+
+
                                         <img align="center" alt="" src="https://gallery.mailchimp.com/a5800eed8cadff70bf999bc29/images/c81b4240-a42a-466f-86d6-aaa1ed9f4279.png" width="564" style="max-width: 1200px; padding-bottom: 0px; vertical-align: bottom; display: inline !important; border-top-left-radius: 0%; border-top-right-radius: 0%; border-bottom-right-radius: 0%; border-bottom-left-radius: 0%;" class="mcnImage">
-                                    
-                                
+
+
                             </td>
                         </tr>
                     </tbody></table>
@@ -663,15 +664,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-                        
+
                             <h1>April 2020 Newsletter</h1>
 
 <p><span style="font-size:12px"><em>This is a monthly newsletter of PSL model releases, events, and updates.</em><br>
@@ -683,7 +684,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -698,15 +699,15 @@
       <tbody class="mcnBoxedTextBlockOuter">
         <tr>
             <td valign="top" class="mcnBoxedTextBlockInner">
-                
+
                         <!--[if gte mso 9]>
                         <td align="center" valign="top" ">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width:100%;" class="mcnBoxedTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td style="padding-top:9px; padding-left:18px; padding-bottom:9px; padding-right:18px;">
-                        
+
                             <table border="0" cellspacing="0" class="mcnTextContentContainer" width="100%" style="min-width: 100% !important;background-color: #F4F4F4;border: 1px solid;">
                                 <tbody><tr>
                                     <td valign="top" class="mcnTextContent" style="padding: 18px;color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;text-align: left;">
@@ -727,7 +728,7 @@
                         <!--[if gte mso 9]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if gte mso 9]>
                 </tr>
                 </table>
@@ -743,15 +744,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px;color: #222222;">
-                        
+
                             <h1><a href="https://github.com/PSLmodels/OG-USA" target="_blank"><strong>OG-USA</strong></a></h1>
 
 <p dir="ltr" style="color: #222222;"><em><span style="font-size:12px">An overlapping-generations model for evaluating fiscal policy in the United States</span></em></p>
@@ -786,7 +787,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -805,7 +806,7 @@
                         </td>
                     </tr>
                 </tbody></table>
-<!--            
+<!--
                 <td class="mcnDividerBlockInner" style="padding: 18px;">
                 <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
 -->
@@ -820,15 +821,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px;color: #222222;">
-                        
+
                             <h1><a href="https://github.com/PSLmodels/ParamTools" target="_blank"><span style="font-size:24px"><strong>ParamTools</strong></span></a></h1>
 
 <p dir="ltr" style="color: #222222;"><span style="font-size:13px"><em>A library for parameter processing and validation with a focus on computational modeling projects</em></span></p>
@@ -861,7 +862,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -880,7 +881,7 @@
                         </td>
                     </tr>
                 </tbody></table>
-<!--            
+<!--
                 <td class="mcnDividerBlockInner" style="padding: 18px;">
                 <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
 -->
@@ -895,15 +896,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px;color: #222222;">
-                        
+
                             <h1><a href="https://github.com/PSLmodels/Tax-Brain" target="_blank"><span style="font-size:24px"><strong>Tax-Brain</strong></span></a></h1>
 
 <p dir="ltr" style="color: #222222;"><span style="font-size:13px"><em>An integrator package for multiple open source tax models</em></span></p>
@@ -920,7 +921,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -939,7 +940,7 @@
                         </td>
                     </tr>
                 </tbody></table>
-<!--            
+<!--
                 <td class="mcnDividerBlockInner" style="padding: 18px;">
                 <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
 -->
@@ -954,15 +955,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px;color: #222222;">
-                        
+
                             <h1><a href="https://github.com/PSLmodels/Tax-Calculator" target="_blank"><span style="font-size:24px"><strong>Tax-Calculator</strong></span></a></h1>
 
 <p dir="ltr" style="color: #222222;"><span style="font-size:13px"><em>A USA federal individual income and payroll tax microsimulation model</em></span></p>
@@ -978,7 +979,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -997,7 +998,7 @@
                         </td>
                     </tr>
                 </tbody></table>
-<!--            
+<!--
                 <td class="mcnDividerBlockInner" style="padding: 18px;">
                 <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
 -->
@@ -1012,15 +1013,15 @@
                         <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
                         <tr>
                         <![endif]-->
-                      
+
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
                 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
                     <tbody><tr>
-                        
+
                         <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-                        
+
                             <span style="font-size:14px"><u><strong>PSL Catalog</strong></u></span>
 
 <ul>
@@ -1040,7 +1041,7 @@
                         <!--[if mso]>
                         </td>
                         <![endif]-->
-                
+
                         <!--[if mso]>
                         </tr>
                         </table>
@@ -1084,12 +1085,12 @@
                                     <table align="center" border="0" cellspacing="0" cellpadding="0">
                                     <tr>
                                     <![endif]-->
-                                    
+
                                         <!--[if mso]>
                                         <td align="center" valign="top">
                                         <![endif]-->
-                                        
-                                        
+
+
                                             <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
                                                 <tbody><tr>
                                                     <td valign="top" style="padding-right:10px; padding-bottom:9px;" class="mcnFollowContentItemContainer">
@@ -1098,12 +1099,12 @@
                                                                 <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
                                                                     <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
                                                                         <tbody><tr>
-                                                                            
+
                                                                                 <td align="center" valign="middle" width="24" class="mcnFollowIconContent">
                                                                                     <a href="https://twitter.com/PSLmodels" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/color-twitter-48.png" style="display:block;" height="24" width="24" class=""></a>
                                                                                 </td>
-                                                                            
-                                                                            
+
+
                                                                         </tr>
                                                                     </tbody></table>
                                                                 </td>
@@ -1112,16 +1113,16 @@
                                                     </td>
                                                 </tr>
                                             </tbody></table>
-                                        
+
                                         <!--[if mso]>
                                         </td>
                                         <![endif]-->
-                                    
+
                                         <!--[if mso]>
                                         <td align="center" valign="top">
                                         <![endif]-->
-                                        
-                                        
+
+
                                             <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
                                                 <tbody><tr>
                                                     <td valign="top" style="padding-right:10px; padding-bottom:9px;" class="mcnFollowContentItemContainer">
@@ -1130,12 +1131,12 @@
                                                                 <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
                                                                     <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
                                                                         <tbody><tr>
-                                                                            
+
                                                                                 <td align="center" valign="middle" width="24" class="mcnFollowIconContent">
                                                                                     <a href="https://www.pslmodels.org" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/color-link-48.png" style="display:block;" height="24" width="24" class=""></a>
                                                                                 </td>
-                                                                            
-                                                                            
+
+
                                                                         </tr>
                                                                     </tbody></table>
                                                                 </td>
@@ -1144,16 +1145,16 @@
                                                     </td>
                                                 </tr>
                                             </tbody></table>
-                                        
+
                                         <!--[if mso]>
                                         </td>
                                         <![endif]-->
-                                    
+
                                         <!--[if mso]>
                                         <td align="center" valign="top">
                                         <![endif]-->
-                                        
-                                        
+
+
                                             <table align="left" border="0" cellpadding="0" cellspacing="0" style="display:inline;">
                                                 <tbody><tr>
                                                     <td valign="top" style="padding-right:0; padding-bottom:9px;" class="mcnFollowContentItemContainer">
@@ -1162,12 +1163,12 @@
                                                                 <td align="left" valign="middle" style="padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:9px;">
                                                                     <table align="left" border="0" cellpadding="0" cellspacing="0" width="">
                                                                         <tbody><tr>
-                                                                            
+
                                                                                 <td align="center" valign="middle" width="24" class="mcnFollowIconContent">
                                                                                     <a href="https://github.com/PSLmodels" target="_blank"><img src="https://cdn-images.mailchimp.com/icons/social-block-v2/color-github-48.png" style="display:block;" height="24" width="24" class=""></a>
                                                                                 </td>
-                                                                            
-                                                                            
+
+
                                                                         </tr>
                                                                     </tbody></table>
                                                                 </td>
@@ -1176,11 +1177,11 @@
                                                     </td>
                                                 </tr>
                                             </tbody></table>
-                                        
+
                                         <!--[if mso]>
                                         </td>
                                         <![endif]-->
-                                    
+
                                     <!--[if mso]>
                                     </tr>
                                     </table>
@@ -1209,7 +1210,7 @@
                         </td>
                     </tr>
                 </tbody></table>
-<!--            
+<!--
                 <td class="mcnDividerBlockInner" style="padding: 18px;">
                 <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
 -->
@@ -1250,7 +1251,7 @@
 
 
 
-                     
+
       <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
       <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>

--- a/about.html
+++ b/about.html
@@ -33,6 +33,7 @@
                     <li class="nav-item active"><a class="nav-link" href="events.html">Events</a></li>
                     <li class="nav-item active"><a class="nav-link" href="Newsletter/archive.html">Newsletter</a></li>
                     <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
                 </ul>
             </div>
             <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">

--- a/events.html
+++ b/events.html
@@ -36,6 +36,7 @@
                     <li class="nav-item active"><a class="nav-link" href="events.html">Events</a></li>
                     <li class="nav-item active"><a class="nav-link" href="Newsletter/archive.html">Newsletter</a></li>
                     <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
                 </ul>
             </div>
             <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
                     <li class="nav-item active"><a class="nav-link" href="events.html">Events</a></li>
                     <li class="nav-item active"><a class="nav-link" href="Newsletter/archive.html">Newsletter</a></li>
                     <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
                 </ul>
             </div>
             <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">
@@ -67,7 +68,7 @@
                                 Contribute
                             </div>
                             <div class="card-body">
-                                PSL is developed by a community of technical contributors. Learn how to contribute to library projects or add a new project to the library.  
+                                PSL is developed by a community of technical contributors. Learn how to contribute to library projects or add a new project to the library.
                             </div>
                         </div>
                     </a>
@@ -79,7 +80,7 @@
                                 News
                             </div>
                             <div class="card-body">
-                                <a class="twitter-timeline" href="https://twitter.com/PSLmodels?ref_src=twsrc%5Etfw" data-chrome="noheader nofooter" data-tweet-limit="3">Tweets by PSLmodels</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>  
+                                <a class="twitter-timeline" href="https://twitter.com/PSLmodels?ref_src=twsrc%5Etfw" data-chrome="noheader nofooter" data-tweet-limit="3">Tweets by PSLmodels</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
This PR adds a donate link to the top of the webpages on the PSLmodels.org site.  The link takes users to PSL's Open Collective page, where tax-deductible contributions can be made to support PSL.