### PR TITLE
Fix links in catalog page

### DIFF
--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -45,7 +45,7 @@
             <br>
             <div class="accordion" id="accordionParent">
                 <!-- Create a collapsible card for each model in PSL -->
-                
+
                     <div class="card">
                         <div class="card-header" id="Behavioral-Responses" style="background-color:#e4e9ec">
                                 <h2>
@@ -85,7 +85,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Cost-of-Capital-Calculator" style="background-color:#e4e9ec">
                                 <h2>
@@ -124,7 +124,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="OG-USA" style="background-color:#e4e9ec">
                                 <h2>
@@ -163,7 +163,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="PCI-China" style="background-color:#e4e9ec">
                                 <h2>
@@ -202,7 +202,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="ParamTools" style="background-color:#e4e9ec">
                                 <h2>
@@ -228,7 +228,7 @@
                                 <h6>Maintainers</h6>
                                 <ul><li>Hank Doupe</li></ul>
                                 <p><a href="https://github.com/PSLmodels/ParamTools#readme">Code repository</a></p>
-                                <p><a href="https://paramtools.org">User documentation</a>
+                                <p><a href="https://paramtools.dev">User documentation</a>
 </p><p><a href="https://github.com/PSLmodels/ParamTools/blob/master/CONTRIBUTING.md">Contributor documentation</a>
 </p><p><a href="https://github.com/PSLmodels/ParamTools/releases/latest">Recent changes</a>
 </p>
@@ -242,7 +242,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Brain" style="background-color:#e4e9ec">
                                 <h2>
@@ -283,7 +283,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Calculator" style="background-color:#e4e9ec">
                                 <h2>
@@ -323,7 +323,7 @@
                             </script>
                         </div>
                     </div>
-                
+
                     <div class="card">
                         <div class="card-header" id="Tax-Cruncher" style="background-color:#e4e9ec">
                                 <h2>
@@ -363,7 +363,7 @@
                             </script>
                         </div>
                     </div>
-                
+
             </div>
         </div>
     </body>

--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -111,8 +111,8 @@
                                 <h6>Maintainers</h6>
                                 <ul><li>Jason DeBacker</li></ul>
                                 <p><a href="https://github.com/PSLmodels/Cost-of-Capital-Calculator#readme">Code repository</a></p>
-                                <p><a href="https://github.com/open-source-economics/Cost-of-Capital-Calculator/blob/master/Guides/CCC_Guide.pdf">User documentation</a>
-</p><p><a href="http://www.ospc.org/ccc/">Link to webapp</a>
+                                <p>User documentation: <a href="https://github.com/open-source-economics/Cost-of-Capital-Calculator/blob/master/Guides/CCC_Guide.pdf">Model Overview</a>, <a href="https://cost-of-capital-calculator.readthedocs.io/en/latest/">ReadTheDocs Contributor and API Guide</a>
+</p><p><a href="https://compute.studio/PSLmodels/Cost-of-Capital-Calculator/">Link to webapp</a>
 </p>
                             </div>
                             <script type="text/javascript">
@@ -150,8 +150,8 @@
                                 <h6>Maintainers</h6>
                                 <ul><li><a href="https://sites.google.com/site/rickecon/">Richard Evans</a></li><li><a href="http://jasondebacker.com">Jason DeBacker</a></li></ul>
                                 <p><a href="https://github.com/PSLmodels/OG-USA#readme">Code repository</a></p>
-                                <p><a href="https://github.com/open-source-economics/OG-USA/blob/master/documentation/OGUSAdoc.pdf">User documentation</a>
-</p><p><a href="https://github.com/open-source-economics/OG-USA#usingcontributing-to-og-usa">Contributor documentation</a>
+                                <p>User documentation: <a href="https://github.com/PSLmodels/OG-USA/blob/master/docs/OGUSAdoc.pdf">Model Overview</a>, <a href="https://og-usa.readthedocs.io/en/latest/">ReadTheDocs Contributor and API Guide</a>
+</p><p><a href="https://compute.studio/PSLmodels/OG-USA/">Link to webapp</a>
 </p>
                             </div>
                             <script type="text/javascript">


### PR DESCRIPTION
This PR fixes links for `ParamTools`, `Cost-of-Capital-Calculator`, and `OG-USA` on the PSL Models catalog page.