### PR TITLE
[WIP] Citations page for Tax-Calculator

### DIFF
--- a/citations.html
+++ b/citations.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+    <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
+        <meta charset="utf-8">
+        <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+        <title>Citations</title>
+        <!-- include bootstrap -->
+        <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+        <link rel="stylesheet" href="CSS/page.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body id="page">
+        <nav class="navbar navbar-expand-md navbar-light sticky-top" style="background-color:white">
+            <div>
+                <a href="index.html" class="navbar-brand"><img src="imgs/PSL.svg" height="40"></a>
+            </div>
+            <button class="navbar-toggler" data-toggle="collapse" data-target="#dropdownMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="dropdownMenu">
+                <ul class="navbar-nav">
+                    <li class="nav-item active"><a class="nav-link" href="Catalog/index.html">Catalog</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="about.html">About</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="events.html">Events</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="Newsletter/archive.html">Newsletter</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="http://discourse.pslmodels.org/">Forum</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="https://opencollective.com/psl">Donate</a></li>
+                </ul>
+            </div>
+            <span class="navbar-text" style="float:right; font-family:'Courier New', Courier, monospace; margin-right:2%">
+                Open Models == Better Policy
+            </span>
+        </nav>
+        <div class="container" id="content">
+            <h1 style="margin-top:20px">Citations</h1>
+            <br>
+<p>Highlights of academic publications, significant policy papers, and testimony using Tax-Calculator.</p>
+<script src=”https://bibbase.org/show?bib=https%3A%2F%2Fapi.zotero.org%2Fgroups%2F2524233%2Fitems%3Fkey%3DdpBqlKH3mVeVV34ChkGUdzI5%26format%3Dbibtex%26limit%3D100&msg=embed″></script>
+
+        </div>
+    </body>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</html>

--- a/citations.html
+++ b/citations.html
@@ -44,7 +44,11 @@
             <h1 style="margin-top:20px">Citations</h1>
             <br>
 <p>Highlights of academic publications, significant policy papers, and testimony using Tax-Calculator.</p>
-<script src=”https://bibbase.org/show?bib=https%3A%2F%2Fapi.zotero.org%2Fgroups%2F2524233%2Fitems%3Fkey%3DdpBqlKH3mVeVV34ChkGUdzI5%26format%3Dbibtex%26limit%3D100&msg=embed″></script>
+
+<script src="https://bibbase.org/show?bib=https%3A%2F%2Fapi.zotero.org%2Fgroups%2F2524233%2Fitems%3Fkey%3DFZ7jwso5hCtHWE0gDslIe1sn%26format%3Dbibtex%26limit%3D100&jsonp=1"></script>
+
+
+
 
         </div>
     </body>

--- a/citations.html
+++ b/citations.html
@@ -43,16 +43,14 @@
         <div class="container" id="content">
             <h1 style="margin-top:20px">Citations</h1>
             <br>
-<p>Highlights of academic publications, significant policy papers, and testimony using Tax-Calculator.</p>
 
-<script src="https://bibbase.org/show?bib=https%3A%2F%2Fapi.zotero.org%2Fgroups%2F2524233%2Fitems%3Fkey%3DFZ7jwso5hCtHWE0gDslIe1sn%26format%3Dbibtex%26limit%3D100&jsonp=1"></script>
+<p>List citations for each PSL project here.</p>
 
-
+<UL>
+    <LI> <a href="https://pslmodels.github.io/OG-USA/content/citations.html">OG-USA</a>
+</UL>
 
 
         </div>
     </body>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 </html>


### PR DESCRIPTION
This PR introduces one way to display project citations discussed in #186. Here, just for example's sake, a new `citations.html` page has been created that lists only OG-USA and then directs to the citations page on their Jupyter Book documentation site.

I'm thinking the following:

1. Scrape the whole `.bib` file of citations for Tax-Calculator from Zotero using something similar to the following:

``` shell
curl -H 'Zotero-API-Version: 2' -H 'Zotero-API-Key: <key>' 'https://api.zotero.org/users/6708260/items?format=bibtex'
```

2. Use [Launchd](https://www.launchd.info), the same program that @Peter-Metz uses to update the `PSL_catalog.json` file daily, to scrape this `.bib` file regularly (probably daily) and push it to the Tax-Calculator Jupyter Book docs – The `.bib` file renders automatically as a page with formatted citations which @jdebacker shows in #186.
3. The GH action which builds the JB docs daily will take care of the rest.

If this doesn't sit well, a new "citations" link under each project on the `catalog` page can be added which links to that project's citations within their Jupyter Book docs.

@MattHJensen @Peter-Metz