### PR TITLE
PSL demo day -- featured event

### DIFF
--- a/events.html
+++ b/events.html
@@ -48,8 +48,8 @@
                 <div class="row" style="background-image: url('imgs/banner.svg')">
                     <div class="col-md-9 event-banner">
                         <p class="lead">Featured Event</p>
-                        <a href="https://www.aei.org/events/webinar-the-policy-simulation-library-dc-meeting-dynamic-tax-modeling-with-the-new-og-usa-web-application/" class="event-link"><h2>Webinar –– The PSL DC meeting: Dynamic tax modeling with the new OG-USA web application</h2></a>
-                        <h6>Thursday, April 16, 2020 | 2:00 pm to 2:45 pm EDT</h6>
+                        <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MWpsMnFoYXIxMjlodXJrcjAxM3BxazN2bjcgcHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBn&tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com" class="event-link"><h2>Webinar –– PSL demo day: How to create policy reforms for use with PSL models</h2></a>
+                        <h6>Monday, November 2, 2020 | 11:30 am to 12:00 pm ET</h6>
                     </div>
                     <div class="col-md-3 event-picture">
                         <img src="imgs/PSL.jpg" height="350">


### PR DESCRIPTION
Updates the featured event to display the first PSL demo day on November 2

https://htmlpreview.github.io/?https://github.com/Peter-Metz/PSL-Core/blob/featured/events.html