### PR TITLE
Add OpenFisca-UK to PSL Catalog register.json

### DIFF
--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -46,7 +46,7 @@
     },
     {
         "org": "PSLmodels",
-        "repo": "openfisca-uk",
+        "repo": "OpenFisca-UK",
         "branch": "master"
     }
 ]

--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -46,7 +46,7 @@
     },
     {
         "org": "PSLmodels",
-        "repo": "OpenFisca-UK",
+        "repo": "openfisca-uk",
         "branch": "master"
     }
 ]

--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -43,5 +43,10 @@
         "org": "PSLmodels",
         "repo": "microdf",
         "branch": "master"
+    },
+    {
+        "org": "PSLmodels",
+        "repo": "OpenFisca-UK",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
See https://github.com/nikhilwoodruff/openfisca-uk/issues/22 for the checklist of PSL criteria - all MUST criteria have been met except for the moving of the repository into the PSLmodels organisation. Let me know if there's any other procedure to follow here.