### PR TITLE
Minor amendments to catalog builder action

### DIFF
--- a/.github/workflows/update_catalog.yml
+++ b/.github/workflows/update_catalog.yml
@@ -1,7 +1,6 @@
 name: Update PSL catalog
 on:
-  schedule:
-    - cron: '0 1 * * *'
+  push:
 
 jobs:
   build_catalog:

--- a/.github/workflows/update_catalog.yml
+++ b/.github/workflows/update_catalog.yml
@@ -7,22 +7,8 @@ jobs:
   build_catalog:
     runs-on: ubuntu-latest
     steps:
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%m-%d-%Y')"
-
     - name: Checkout repo
       uses: actions/checkout@v2
-
-    - name: Pull upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v2.1
-      with:
-        upstream_repository: PSLmodels/PSL-Infrastructure
-        upstream_branch: master
-        target_branch: master
-        git_pull_args: --unshallow
-        git_push_args: -f
 
     - name: Setup Miniconda
       uses: conda-incubator/setup-miniconda@v2.0.0
@@ -48,5 +34,5 @@ jobs:
         git config user.email github-actions@github.com
 
         git add -A
-        git commit -m "Update PSL-catalog on $(date +'%Y-%m-%d')"
+        git commit --allow-empty -m "Update PSL-catalog on $(date +'%Y-%m-%d')"
         git push


### PR DESCRIPTION
@hdoupe I realized that the catalog builder action will fail if empty commits are not allowed (no changes are made to the catalog), so I've added `--allow-empty` to the commit flags.

Also:
- The miniconda setup action has been bumped to 2.0.1
- The pull-upstream-changes action has been removed (don't need to pull from upstream if you're operating on master)
- The "Get current date" step has been removed (it's unused)