### PR TITLE
Add taxdata to register

### DIFF
--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -48,5 +48,10 @@
         "org": "PSLmodels",
         "repo": "openfisca-uk",
         "branch": "master"
+    },
+    {
+        "org": "PSLmodels",
+        "repo": "taxdata",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
This PR adds taxdata to the PSL models register. The catalog listing is [here](https://github.com/PSLmodels/taxdata/blob/master/PSL_catalog.json). Let me know if there's anything else I need to add in.