### PR TITLE
Fix page builder GH action

### DIFF
--- a/Tools/Page-Builder/make_pages.sh
+++ b/Tools/Page-Builder/make_pages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pandoc -s -o ../../Community/contribute.html ../../Community/contribute.md -H head.html -B nav.html
-pandoc -s -o ../../Community/council.html ../../Community/council.md -H head.html -B nav.html
-pandoc -s -o ../../Community/roadmap.html ../../Community/roadmap.md -H head.html -B nav.html
-pandoc -s -o ../../Community/initiatives.html ../../Community/initiatives.md -H head.html -B nav.html
-pandoc -s -o ../../Catalog/library_criteria.html ../../Catalog/library_criteria.md -H head.html -B nav.html
+pandoc -s -o ../../Community/contribute.html ../../Community/contribute.md -H head.html -B nav.html --css ../../CSS/page.css
+pandoc -s -o ../../Community/council.html ../../Community/council.md -H head.html -B nav.html --css ../../CSS/page.css
+pandoc -s -o ../../Community/roadmap.html ../../Community/roadmap.md -H head.html -B nav.html --css ../../CSS/page.css
+pandoc -s -o ../../Community/initiatives.html ../../Community/initiatives.md -H head.html -B nav.html --css ../../CSS/page.css
+pandoc -s -o ../../Catalog/library_criteria.html ../../Catalog/library_criteria.md -H head.html -B nav.html --css ../../CSS/page.css


### PR DESCRIPTION
This PR fixes the problem of introducing breaking changes to the CSS of HTML pages when running the page builder GH action (#240 and #210). The solution is to make sure that the builder shell script `make_pages.sh` links each `pandoc` command to the `page.css` CSS style.

cc @Peter-Metz 