### PR TITLE
Add NY Fed DSGE model to PSL Catalog

### DIFF
--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -53,5 +53,10 @@
         "org": "PSLmodels",
         "repo": "taxdata",
         "branch": "master"
+    },
+    {
+        "org": "FRBNY-DSGE",
+        "repo": "DSGE.jl",
+        "branch": "main"
     }
 ]

--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -141,6 +141,7 @@ def get_from_github_api(project, config):
 
 
 def make_id(name):
+    name = name.replace('.', '')
     return "-".join(name.split())
 
 


### PR DESCRIPTION
This PR adds the [NYFRB DSGE model](https://github.com/FRBNY-DSGE/DSGE.jl) to the PSL Catalog.

The update will be reflected on pslmodels.org when the catalog builder GH action is triggered tonight.

cc @jdebacker 