### PR TITLE
Update with new council member

### DIFF
--- a/Community/council.md
+++ b/Community/council.md
@@ -1,9 +1,10 @@
-# PSL Leadership Council, Version 1.1.0
+# PSL Leadership Council, Version 1.2.0
 
 ## Council
 
 | Member          | Represented Project        | Email                    |
 |-----------------|----------------------------|--------------------------|
+| Daniel Bunn     | capital-cost-recovery      | dbunn@taxfoundation.org  |
 | Jason DeBacker  | Cost-of-Capital-Calculator | jason.debacker@gmail.com |
 | Henry Doupe     | ParamTools                 | henrymdoupe@gmail.com    |
 | Richard Evans   | OG-USA                     | rickecon@gmail.com       |
@@ -16,14 +17,14 @@
 | Nikhil Woodruff | OpenFisca-UK               | nikhil.woodruff@outlook.com |
 
 
-## Bylaws 
+## Bylaws
 
-- At most one representative for each PSL cataloged project and PSLmodels/PSL. 
-- No one person may represent more than one project. 
-- Majoritarian decision-making with a quorum of half of the members or more. 
+- At most one representative for each PSL cataloged project and PSLmodels/PSL.
+- No one person may represent more than one project.
+- Majoritarian decision-making with a quorum of half of the members or more.
 - Projects may join PSL based on conformance to PSL criteria and mission, subject to a PSL leadership council vote in a private forum, such as a PSL leadership council conference call.
-- Substantive changes to the PSL criteria, mission, or other foundational texts are subject to a PSL leadership council vote in a public forum, such as a GitHub pull request to PSLmodels/PSL. 
+- Substantive changes to the PSL criteria, mission, or other foundational texts are subject to a PSL leadership council vote in a public forum, such as a GitHub pull request to PSLmodels/PSL.
 
-## Log 
+## Log
 
 Version 1.0.0 ratified 20 March 2019 with members Henry Doupe, Jason DeBacker, Matthew Jensen, Richard Evans, and Martin Holmer present.


### PR DESCRIPTION
This PR adds Daniel Bunn to the list of PSL Leadership Council members, representing the `capital-cost-recovery` project.