### PR TITLE
Add capital-cost-recovery project to PSL catalog

### DIFF
--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -55,8 +55,13 @@
         "branch": "master"
     },
     {
-        "org": "FRBNY-DSGE",
+        "org": "PSLmodels",
         "repo": "DSGE.jl",
         "branch": "main"
-    }
+    },
+    {
+        "org": "TaxFoundation",
+        "repo": "capital-cost-recovery",
+        "branch": "master"
+    }    
 ]

--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -173,5 +173,8 @@ def make_links(item):
                 ("link_to_webapp", "Link to webapp")]
     links = ""
     for key, section_name in sections:
-        links += create_link(item[key], section_name)
+        try:
+            links += create_link(item[key], section_name)
+        except:
+            pass
     return links


### PR DESCRIPTION
Adds `capital-cost-recovery` to the PSL register. A GH action will add it to the catalog tonight.

In addition, this PR makes the previously required fields of PSL_catalog.json optional.