### PR TITLE
Update events page and featured demo day

### DIFF
--- a/events.html
+++ b/events.html
@@ -71,8 +71,8 @@
                 <div class="row" style="background-image: url('imgs/banner.svg')">
                     <div class="col-md-9 event-banner">
                         <p class="lead">Featured Event</p>
-                        <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA4MDlUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&scp=ALL" class="event-link"><h2>Webinar –– PSL demo day: Interactive data visualization with Bokeh</h2></a>
-                        <h6>Monday, August 23, 2021 | 11:30 am to 12:00 pm ET</h6>
+                        <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=NTk5N3ByNm9uNGV1NW80dXI4ZGtyazAwbHYgcHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBn&tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com" class="event-link"><h2>Webinar –– PSL Demo Day: Nikhil Woodruff on PolicyEngine UK</h2></a>
+                        <h6>Wednesday, September 8, 2021 | 12:00 pm to 12:30 pm ET</h6>
                     </div>
                     <div class="col-md-3 event-picture">
                         <img src="imgs/PSL.jpg" height="350">
@@ -80,27 +80,23 @@
                 </div>
                 <div class="row" >
                     <div class="col-sm-6 event-col">
-                        <h4 style="padding-top: 30px">August Community Events</h4>
-                        <p class="lead event-button">OG-USA Developer Meeting | August 2, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA4MDJUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Community Call | August 3, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA4MDNUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Demo Day | August 9, 11:30 am ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA4MDlUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Leadership Council Call | August 10, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA4MTBUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">OG-USA Developer Meeting | August 16, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA4MDJUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Community Call | August 17, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA4MDNUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Demo Day | August 23, 11:30 am ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA4MDlUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Leadership Council Call | August 24, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA4MTBUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">OG-USA Developer Meeting | August 30, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA4MDJUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Community Call | August 31, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA4MDNUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <h4 style="padding-top: 30px">September Community Events</h4>
+                        <p class="lead event-button">PSL Leadership Council Call | September 7, 3:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA5MDdUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">PSL Demo Day | Septempber 8, 12:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=NTk5N3ByNm9uNGV1NW80dXI4ZGtyazAwbHYgcHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBn&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">OG-USA Developer Meeting | September 13, 12:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA5MTNUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">PSL Community Call | September 14, 3:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA5MTRUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">PSL Demo Day | September 20, 11:30 am ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA5MjBUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">PSL Leadership Council Call | September 21, 3:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA5MDdUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">OG-USA Developer Meeting | September 27, 12:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA5MjdUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
+                        <p class="lead event-button">PSL Community Call | September 28, 3:00 pm ET</p>
+                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA5MjhUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
                     </div>
                     <div class="col-sm-6">
                         <h4 style="padding: 30px 0 10px">PSL Community Calendar</h4>


### PR DESCRIPTION
The next Demo Day will feature @nikhilwoodruff on PolicyEngine UK. Wednesday, September 8 at 12p ET.