### PR TITLE
Updates to events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -71,33 +71,14 @@
                 <div class="row" style="background-image: url('imgs/banner.svg')">
                     <div class="col-md-9 event-banner">
                         <p class="lead">Featured Event</p>
-                        <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA5MjBUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com" class="event-link"><h2>Webinar –– PSL Demo Day: Hank Doupe on Deploying Apps on C/S</h2></a>
-                        <h6>Monday, September 20, 2021 | 11:30 am to 12:00 pm ET</h6>
+                        <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTEwMThUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com" class="event-link"><h2>Webinar –– PSL Demo Day: James Hiebert on using the Tax-Calculator model with the American Community Survey</h2></a>
+                        <h6>Monday, October 18, 2021 | 11:30 am to 12:00 pm ET</h6>
                     </div>
                     <div class="col-md-3 event-picture">
                         <img src="imgs/PSL.jpg" height="350">
                     </div>
                 </div>
                 <div class="row" >
-                    <!-- <div class="col-sm-6 event-col">
-                        <h4 style="padding-top: 30px">September Community Events</h4>
-                        <p class="lead event-button">PSL Leadership Council Call | September 7, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA5MDdUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Demo Day | September 8, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=NTk5N3ByNm9uNGV1NW80dXI4ZGtyazAwbHYgcHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBn&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">OG-USA Developer Meeting | September 13, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA5MTNUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Community Call | September 14, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA5MTRUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Demo Day | September 20, 11:30 am ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=Mmx0Nm1jcTBtajl1dXVyZWl0cHVqMmdhMGhfMjAyMTA5MjBUMTUzMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Leadership Council Call | September 21, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA5MDdUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">OG-USA Developer Meeting | September 27, 12:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA5MjdUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                        <p class="lead event-button">PSL Community Call | September 28, 3:00 pm ET</p>
-                        <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA5MjhUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                    </div> -->
                     <div class="col-sm-12">
                         <h4 style="padding: 30px 10% 10px">PSL Community Calendar</h4>
                         <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FNew_York&showTitle=0&showTabs=0&src=cHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=Y19pbWVsdHFoaTJsMWlpNWo2cnJ1bDlyZ202Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%237CB342&color=%23E67C73" style="border-width:0; margin:0 10% 0 10%" width="80%" height="500" frameborder="0" scrolling="no"></iframe>                    </div>

--- a/events.html
+++ b/events.html
@@ -79,7 +79,7 @@
                     </div>
                 </div>
                 <div class="row" >
-                    <div class="col-sm-6 event-col">
+                    <!-- <div class="col-sm-6 event-col">
                         <h4 style="padding-top: 30px">September Community Events</h4>
                         <p class="lead event-button">PSL Leadership Council Call | September 7, 3:00 pm ET</p>
                         <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=N21kNjk4MnJhYTlxaDRncXBzOTYwdjVuMW9fMjAyMTA5MDdUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
@@ -97,10 +97,10 @@
                         <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=ZGg5ZnFmYzFoaXZodnFxMWRwdjcwMDdmMzZfMjAyMTA5MjdUMTYwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
                         <p class="lead event-button">PSL Community Call | September 28, 3:00 pm ET</p>
                         <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MXU3bjluZTdrcmY0N2dvMXEzOHBkNmcxcnRfMjAyMTA5MjhUMTkwMDAwWiBwc2xtb2RlbHMub3JnXzN1Z3E2NmJ1NWpmbTY0MmY5aWk0aWt0c3AwQGc&amp;tmsrc=pslmodels.org_3ugq66bu5jfm642f9ii4iktsp0%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
-                    </div>
-                    <div class="col-sm-6">
-                        <h4 style="padding: 30px 0 10px">PSL Community Calendar</h4>
-                        <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FNew_York&showTitle=0&showTabs=0&src=cHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=Y19pbWVsdHFoaTJsMWlpNWo2cnJ1bDlyZ202Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%237CB342&color=%23E67C73" style="border-width:0" width="100%" height="350" frameborder="0" scrolling="no"></iframe>                    </div>
+                    </div> -->
+                    <div class="col-sm-12">
+                        <h4 style="padding: 30px 10% 10px">PSL Community Calendar</h4>
+                        <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FNew_York&showTitle=0&showTabs=0&src=cHNsbW9kZWxzLm9yZ18zdWdxNjZidTVqZm02NDJmOWlpNGlrdHNwMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=Y19pbWVsdHFoaTJsMWlpNWo2cnJ1bDlyZ202Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%237CB342&color=%23E67C73" style="border-width:0; margin:0 10% 0 10%" width="80%" height="500" frameborder="0" scrolling="no"></iframe>                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
1. Resolves #276 -- removes list of calls in favor of larger community calendar
2. Updates featured event to October 18 demo day featuring James Hiebert on using Tax-Calculator with the ACS