### PR TITLE
Build catalog on push to master

### DIFF
--- a/.github/workflows/update_catalog.yml
+++ b/.github/workflows/update_catalog.yml
@@ -2,6 +2,9 @@ name: Update PSL catalog
 on:
   schedule:
     - cron: '0 1 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   build_catalog:


### PR DESCRIPTION
This PR updates the `update_catalog` action to also build the catalog on a push to master (not just daily).