### PR TITLE
Fix http error

### DIFF
--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -8,6 +8,8 @@ from jinja2 import Template
 
 import re
 
+# headers for requests to GitHub API
+HEADER = {'User-Agent': 'request'}
 
 class SectionHeadersDoNotExist(Exception):
     pass
@@ -121,7 +123,7 @@ def _get_from_github_api(org, repo, branch, filename):
             "docs: Tools/Catalog-Builder/README.md"
         )
     url = f"https://api.github.com/repos/{org}/{repo}/contents/{filename}?ref={branch}"
-    response = requests.get(url)
+    response = requests.request('GET', url, headers=HEADER)
     print(f"GET: {url} {response.status_code}")
     if response.status_code == 403:
         assert "hit rate limit" == 403


### PR DESCRIPTION
This PR fixed an HTTP error where the the GitHub API is not responsive. From [this Stack Overflow thread](https://stackoverflow.com/questions/39907742/github-api-is-responding-with-a-403-when-using-requests-request-function) it appears that using a header in the request is important to avoid this issue.  The changes here implement that and seem to work when I execute the `catalog.py` script locally.