### PR TITLE
`pip` install `requests_mock`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,7 @@ dependencies:
   - bs4
   - jinja2
   - requests
-  - requests_mock
   - pandoc
+  - pip
+pip:
+  - requests_mock


### PR DESCRIPTION
The package wasn't available on `conda`.