### PR TITLE
Added OG-Core to register.json

### DIFF
--- a/Catalog/register.json
+++ b/Catalog/register.json
@@ -6,6 +6,11 @@
   },
   {
     "org": "PSLmodels",
+    "repo": "OG-Core",
+    "branch": "master"
+  },
+  {
+    "org": "PSLmodels",
     "repo": "Cost-of-Capital-Calculator",
     "branch": "master"
   },


### PR DESCRIPTION
This PR adds the OG-Core model to the PSL Catalogue list `register.json`. OG-Core was originally OG-USA, which was subsequently split into two pieces (OG-Core and OG-USA). Because OG-Core has different functionality and documentation that is valuable and separate from the country calibrations, OG-Core should probably be in the catalogue list.

cc: @jdebacker