### PR TITLE
Comment out incubating projects

### DIFF
--- a/Incubating/register.json
+++ b/Incubating/register.json
@@ -3,100 +3,100 @@
     "org": "PSLmodels",
     "repo": "Inverse-Optimal-Tax",
     "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "ui_calculator",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "CGE",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "Business-Taxation",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "Git-Tutorial",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "PCI-Crackdown",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "PCI-Outbreak",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "OG-UK",
-    "branch": "master"
-  },
-  {
-    "org": "Revenue-Academy",
-    "repo": "OG-MYS",
-    "branch": "master"
-  },
-  {
-    "org": "Revenue-Academy",
-    "repo": "OG-IND",
-    "branch": "master"
-  },
-  {
-    "org": "EAPD-DRB",
-    "repo": "OG-ZAF",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "Federal-State-Tax",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "Border-Adjustment-Calculator",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "scf",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "examples",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "PUF-State-Distribution",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "C-TAM",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "PFL-CM",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "COVID-MCS",
-    "branch": "master"
-  },
-  {
-    "org": "PSLmodels",
-    "repo": "Taxes-Investment-Growth",
-    "branch": "master"
   }
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "ui_calculator",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "CGE",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "Business-Taxation",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "Git-Tutorial",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "PCI-Crackdown",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "PCI-Outbreak",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "OG-UK",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "Revenue-Academy",
+  //   "repo": "OG-MYS",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "Revenue-Academy",
+  //   "repo": "OG-IND",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "EAPD-DRB",
+  //   "repo": "OG-ZAF",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "Federal-State-Tax",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "Border-Adjustment-Calculator",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "scf",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "examples",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "PUF-State-Distribution",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "C-TAM",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "PFL-CM",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "COVID-MCS",
+  //   "branch": "master"
+  // },
+  // {
+  //   "org": "PSLmodels",
+  //   "repo": "Taxes-Investment-Growth",
+  //   "branch": "master"
+  // }
 ]


### PR DESCRIPTION
This PR updates the `/Incubating/register.json` file to comment out incubating projects that do not have a `PSL_catalog.json` file in the hopes that this allows the catalog builder to run through.